### PR TITLE
Enforce owner/admin authorization for GET /api/users/{user_id} and add tests

### DIFF
--- a/fastapi_app/app/routers/users.py
+++ b/fastapi_app/app/routers/users.py
@@ -52,8 +52,10 @@ def create_user(payload: UserCreate, session: Session = Depends(get_session)):
 def get_user(
     user_id: int,
     session: Session = Depends(get_session),
-    _: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user),
 ):
+    if current_user.id != user_id and current_user.role != "ROLE_ADMIN":
+        raise HTTPException(status_code=403, detail="Not authorized")
     user = session.get(User, user_id)
     if not user:
         raise HTTPException(status_code=404, detail="User not found")

--- a/fastapi_app/tests/test_auth_users_logs_edges.py
+++ b/fastapi_app/tests/test_auth_users_logs_edges.py
@@ -241,6 +241,71 @@ def test_user_route_requires_auth_and_rejects_invalid_or_stale_token(client):
     assert stale.json()["detail"] == "User no longer exists"
 
 
+def test_user_route_forbids_regular_user_from_reading_other_user(client, db_session):
+    own_user = User(
+        username="own-user@example.com",
+        password="pw",
+        role="ROLE_USER",
+        user_level="1",
+        confirmed=True,
+    )
+    other_user = User(
+        username="other-user@example.com",
+        password="pw",
+        role="ROLE_USER",
+        user_level="1",
+        confirmed=True,
+    )
+    db_session.add_all([own_user, other_user])
+    db_session.commit()
+
+    response = client.get(f"/api/users/{other_user.id}", headers=_auth_header(own_user))
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Not authorized"
+
+
+def test_user_route_allows_admin_to_read_other_user(client, db_session):
+    admin_user = User(
+        username="admin-user@example.com",
+        password="pw",
+        role="ROLE_ADMIN",
+        user_level="1",
+        confirmed=True,
+    )
+    other_user = User(
+        username="other-user-2@example.com",
+        password="pw",
+        role="ROLE_USER",
+        user_level="1",
+        confirmed=True,
+    )
+    db_session.add_all([admin_user, other_user])
+    db_session.commit()
+
+    response = client.get(f"/api/users/{other_user.id}", headers=_auth_header(admin_user))
+
+    assert response.status_code == 200
+    assert response.json()["id"] == other_user.id
+
+
+def test_user_route_allows_regular_user_to_read_own_user(client, db_session):
+    own_user = User(
+        username="own-user-2@example.com",
+        password="pw",
+        role="ROLE_USER",
+        user_level="1",
+        confirmed=True,
+    )
+    db_session.add(own_user)
+    db_session.commit()
+
+    response = client.get(f"/api/users/{own_user.id}", headers=_auth_header(own_user))
+
+    assert response.status_code == 200
+    assert response.json()["id"] == own_user.id
+
+
 def test_admin_eventboard_rejects_non_admin_user(client, db_session):
     user = User(
         username="plain-user@example.com",

--- a/fastapi_app/tests/test_openapi_contract.py
+++ b/fastapi_app/tests/test_openapi_contract.py
@@ -266,6 +266,12 @@ def test_openapi_exposes_filters_station_logs_and_path_lookup(client):
         payload,
         _response_schema(payload, "/api/users/{user_id}"),
     )
+    user_path_get = paths["/api/users/{user_id}"]["get"]
+    assert (
+        user_path_get["description"]
+        == "Returns account fields for one authenticated user. This is not a public profile endpoint."
+    )
+    assert user_path_get["security"] == [{"HTTPBearer": []}]
     assert "properties" in user_response
     assert {
         "id",


### PR DESCRIPTION
### Motivation

- Sørge for at brukeroppslag `/api/users/{user_id}` kun er tilgjengelig for konto-eier eller admin, og at dette håndteres før DB-oppslag.
- Beholde eksisterende 404-oppførsel for ikke-eksisterende brukere.
- Verifisere at OpenAPI beskriver endpointet som et autentisert (ikke-offentlig) konto-endpoint.

### Description

- Endret dependency-signaturen i `get_user` til `current_user: User = Depends(get_current_user)` og la til en autorisasjonssjekk som returnerer `HTTPException(status_code=403, detail="Not authorized")` når `current_user.id != user_id` og `current_user.role != "ROLE_ADMIN"` før DB-oppslag, mens eksisterende 404 for manglende bruker beholdes (`fastapi_app/app/routers/users.py`).
- La til integrasjonstester som dekker at en vanlig bruker får `403` ved oppslag av en annen bruker, at admin får tilgang til andre brukere, og at en bruker fortsatt kan lese egen ID (`fastapi_app/tests/test_auth_users_logs_edges.py`).
- Oppdaterte OpenAPI-kontrakttesten for å forsikre at `/api/users/{user_id}` fortsatt har riktig `description` og `security` (`HTTPBearer`) i `fastapi_app/tests/test_openapi_contract.py`.

### Testing

- Kjørte målrettede pytest-scenarier med `pytest -q fastapi_app/tests/test_auth_users_logs_edges.py::test_user_route_requires_auth_and_rejects_invalid_or_stale_token fastapi_app/tests/test_auth_users_logs_edges.py::test_user_route_forbids_regular_user_from_reading_other_user fastapi_app/tests/test_auth_users_logs_edges.py::test_user_route_allows_admin_to_read_other_user fastapi_app/tests/test_auth_users_logs_edges.py::test_user_route_allows_regular_user_to_read_own_user fastapi_app/tests/test_openapi_contract.py::test_openapi_exposes_filters_station_logs_and_path_lookup`.
- Resultat: alle kjørt tester bestod (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c77a3a69c4832a9299a99d6fc2be81)