### PR TITLE
Reject login for unconfirmed accounts and add test

### DIFF
--- a/fastapi_app/app/routers/auth.py
+++ b/fastapi_app/app/routers/auth.py
@@ -34,7 +34,7 @@ user_service = UserService()
 )
 def login(payload: LoginRequest, session: Session = Depends(get_session)):
     user = user_service.authenticate(session, payload.identifier, payload.password)
-    if not user:
+    if not user or not user.confirmed:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Feil brukernavn eller passord",

--- a/fastapi_app/tests/test_auth_users_logs_edges.py
+++ b/fastapi_app/tests/test_auth_users_logs_edges.py
@@ -60,6 +60,29 @@ def test_login_rejects_wrong_password(client, db_session, monkeypatch):
     assert response.json()["detail"] == "Feil brukernavn eller passord"
 
 
+def test_login_rejects_unconfirmed_account(client, db_session, monkeypatch):
+    monkeypatch.setattr(
+        user_service_module, "verify_password", lambda plain, stored: plain == stored
+    )
+    user = User(
+        username="unconfirmed@example.com",
+        password="correct-password",
+        role="ROLE_USER",
+        user_level="1",
+        confirmed=False,
+    )
+    db_session.add(user)
+    db_session.commit()
+
+    response = client.post(
+        "/api/auth/login",
+        json={"identifier": "unconfirmed@example.com", "password": "correct-password"},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Feil brukernavn eller passord"
+
+
 def test_password_reset_confirm_rejects_unknown_token(client, db_session):
     user = User(
         username="reset-confirm@example.com",


### PR DESCRIPTION
### Motivation
- Prevent unverified accounts from obtaining a JWT by enforcing that only users with a confirmed account can log in.

### Description
- Add a confirmation check to the `login` endpoint so authentication fails when `user.confirmed` is false.
- Preserve the existing error behavior and message by returning a `401` with the same detail when an account is unconfirmed.
- Add `test_login_rejects_unconfirmed_account` to `fastapi_app/tests/test_auth_users_logs_edges.py` which creates an unconfirmed user and asserts a `401` response.

### Testing
- Ran the modified auth tests including `test_login_rejects_unconfirmed_account` and `test_login_rejects_wrong_password` with `pytest`, and they passed.
- The updated test suite confirms the login rejection behavior for both wrong passwords and unconfirmed accounts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c77441d58c832a93b60906c3555c4b)