### PR TITLE
Fix nondeterministic event folder ordering in file mapper

### DIFF
--- a/fastapi_app/app/services/file_mapper.py
+++ b/fastapi_app/app/services/file_mapper.py
@@ -272,7 +272,9 @@ class FileToObjectMapper:
     def _get_folder_content(self, path: Path) -> List[str]:
         if not path.is_dir():
             return []
-        return [entry.name for entry in path.iterdir()]
+        # Always return deterministic ordering so downstream mapping and
+        # observation ordering are stable across filesystems/platforms.
+        return sorted(entry.name for entry in path.iterdir())
 
     def _find_files(self, entries: Iterable[str], suffix: str) -> List[str]:
         suffix_lower = suffix.lower()


### PR DESCRIPTION
### Motivation
- `FileToObjectMapper` relied on `Path.iterdir()` iteration order which can vary by filesystem and caused nondeterministic observation ordering and test flakiness.

### Description
- Return a sorted list of folder names from `_get_folder_content` in `fastapi_app/app/services/file_mapper.py` to make event-folder iteration deterministic.
- Added an explanatory comment that ordering is required to keep downstream mapping and observation ordering stable across platforms.
- No other mapping or parsing logic was changed, only the ordering of returned folder entries.

### Testing
- Ran `pytest -q fastapi_app/tests/test_meteor_ingestion.py::test_file_mapper_reads_realistic_non_crossbearing_sample` and it passed.
- Ran `pytest -q fastapi_app/tests/test_meteor_ingestion.py` and the suite passed with `14 passed, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c77e42825c832a8af0543f2fb1b2ec)