### PR TITLE
Make FileToObjectMapper folder traversal deterministic

### DIFF
--- a/fastapi_app/app/services/file_mapper.py
+++ b/fastapi_app/app/services/file_mapper.py
@@ -272,7 +272,10 @@ class FileToObjectMapper:
     def _get_folder_content(self, path: Path) -> List[str]:
         if not path.is_dir():
             return []
-        return [entry.name for entry in path.iterdir()]
+        # Keep filesystem traversal deterministic so observation ordering does not
+        # change between operating systems/filesystems (important for stable ingest
+        # results and reproducible tests).
+        return sorted(entry.name for entry in path.iterdir())
 
     def _find_files(self, entries: Iterable[str], suffix: str) -> List[str]:
         suffix_lower = suffix.lower()


### PR DESCRIPTION
### Motivation
- Unsigned filesystem iteration yielded non-deterministic observation ordering (e.g. `cam3` before `cam2`) which broke reproducible ingestion and caused test flakiness, so traversal must be stable across platforms.

### Description
- Return a sorted list from `FileToObjectMapper._get_folder_content()` and add an inline comment explaining the need for deterministic directory traversal to preserve stable ingest results and reproducible tests.

### Testing
- Ran `pytest -q fastapi_app/tests/test_meteor_ingestion.py::test_file_mapper_reads_realistic_non_crossbearing_sample` which passed.
- Ran full `pytest -q`; the change did not introduce regressions but one pre-existing failing test remains: `fastapi_app/tests/test_api_compat.py::test_reportmeteor_accepts_multipart_attachments` fails with HTTP 500 due to no mail recipient configured (raising `Recipient missing`), which is unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c780273ec8832a8eeeb1c68c871751)