### PR TITLE
Fix inconsistent meteor reCAPTCHA message and stabilize form test defaults

### DIFF
--- a/fastapi_app/app/routers/forms.py
+++ b/fastapi_app/app/routers/forms.py
@@ -183,7 +183,7 @@ async def report_meteor(request: Request):
     except HTTPException as exc:
         if exc.status_code == 401 and exc.detail == "reCAPTCHA validation failed":
             message = (
-                "Kontaktskjema mottatt, men foresporsel ble ikke autentisert som en "
+                "Observasjon mottatt, men foresporsel ble ikke autentisert som en "
                 "vanlig bruker med reCAPTCHA"
             )
             return JSONResponse(

--- a/fastapi_app/tests/conftest.py
+++ b/fastapi_app/tests/conftest.py
@@ -19,6 +19,7 @@ if TEST_DB_PATH.exists():
 os.environ.setdefault("DATABASE_URL", f"sqlite:///{TEST_DB_PATH}")
 os.environ.setdefault("JWT_SECRET_KEY", "test-secret")
 os.environ.setdefault("ACCESS_TOKEN_EXPIRE_MINUTES", "60")
+os.environ.setdefault("SMTP_SENDER", "noreply@example.com")
 
 from fastapi_app.app.config import get_settings
 from fastapi_app.app.db import Base, SessionLocal, engine, get_session

--- a/fastapi_app/tests/test_api_compat.py
+++ b/fastapi_app/tests/test_api_compat.py
@@ -357,6 +357,7 @@ def test_forms_recaptcha_failure_has_legacy_message_shape(client, monkeypatch):
     assert report.status_code == 401
     assert "message" in report.json()
     assert "error" in report.json()
+    assert "Observasjon mottatt" in report.json()["message"]
 
 
 def test_reportmeteor_accepts_multipart_attachments(client, monkeypatch):


### PR DESCRIPTION
### Motivation
- Correct a user-facing inconsistency where the reCAPTCHA failure message for the meteor report endpoint incorrectly referred to the contact form, and make tests deterministic with a default mail sender.
- Prevent a fragile test from regressing by asserting the corrected message text in the API compatibility tests.

### Description
- Swap the reCAPTCHA failure text so the `/api/forms/contact` endpoint returns the contact-specific message and `/api/forms/meteor-report` returns an observation-specific message in `fastapi_app/app/routers/forms.py`.
- Add a default `SMTP_SENDER` environment variable in `fastapi_app/tests/conftest.py` so tests have a deterministic recipient fallback.
- Add an explicit assertion for the meteor-report reCAPTCHA message in `fastapi_app/tests/test_api_compat.py` to lock in the expected wording.

### Testing
- Ran focused tests with `pytest -q tests/test_api_compat.py::test_forms_recaptcha_failure_has_legacy_message_shape tests/test_api_compat.py::test_reportmeteor_accepts_multipart_attachments`, which passed (`2 passed`).
- Ran the full test suite with `pytest -q`, which passed (`94 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7832e317c832ab402c6feeaaf8f7b)