### PR TITLE
Fix missing mail recipient defaults in test environment

### DIFF
--- a/fastapi_app/tests/conftest.py
+++ b/fastapi_app/tests/conftest.py
@@ -19,6 +19,8 @@ if TEST_DB_PATH.exists():
 os.environ.setdefault("DATABASE_URL", f"sqlite:///{TEST_DB_PATH}")
 os.environ.setdefault("JWT_SECRET_KEY", "test-secret")
 os.environ.setdefault("ACCESS_TOKEN_EXPIRE_MINUTES", "60")
+os.environ.setdefault("CONTACT_RECIPIENT", "contact-test@example.com")
+os.environ.setdefault("METEOR_REPORT_RECIPIENT", "meteor-test@example.com")
 
 from fastapi_app.app.config import get_settings
 from fastapi_app.app.db import Base, SessionLocal, engine, get_session


### PR DESCRIPTION
### Motivation
- `ContactService.handle_report` requires a configured recipient (`meteor_report_recipient`, `contact_recipient` or `smtp_sender`), but the test environment did not provide any, causing multipart `/api/forms/meteor-report` tests to fail with `500 Recipient missing`.

### Description
- Set default environment variables `CONTACT_RECIPIENT` and `METEOR_REPORT_RECIPIENT` in `fastapi_app/tests/conftest.py` so the test app has mail recipients configured without altering production logic.

### Testing
- Ran `pytest -q fastapi_app/tests` before the change which showed 1 failing test (`test_reportmeteor_accepts_multipart_attachments`), and after the change the full suite passed with `94 passed, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7832e317c832ab402c6feeaaf8f7b)