### PR TITLE
Merge open FastAPI port PRs into feature/fastapi-port

### DIFF
--- a/fastapi_app/app/routers/auth.py
+++ b/fastapi_app/app/routers/auth.py
@@ -34,7 +34,7 @@ user_service = UserService()
 )
 def login(payload: LoginRequest, session: Session = Depends(get_session)):
     user = user_service.authenticate(session, payload.identifier, payload.password)
-    if not user:
+    if not user or not user.confirmed:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Feil brukernavn eller passord",

--- a/fastapi_app/app/routers/forms.py
+++ b/fastapi_app/app/routers/forms.py
@@ -183,7 +183,7 @@ async def report_meteor(request: Request):
     except HTTPException as exc:
         if exc.status_code == 401 and exc.detail == "reCAPTCHA validation failed":
             message = (
-                "Kontaktskjema mottatt, men foresporsel ble ikke autentisert som en "
+                "Observasjon mottatt, men foresporsel ble ikke autentisert som en "
                 "vanlig bruker med reCAPTCHA"
             )
             return JSONResponse(

--- a/fastapi_app/app/routers/users.py
+++ b/fastapi_app/app/routers/users.py
@@ -52,8 +52,10 @@ def create_user(payload: UserCreate, session: Session = Depends(get_session)):
 def get_user(
     user_id: int,
     session: Session = Depends(get_session),
-    _: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user),
 ):
+    if current_user.id != user_id and current_user.role != "ROLE_ADMIN":
+        raise HTTPException(status_code=403, detail="Not authorized")
     user = session.get(User, user_id)
     if not user:
         raise HTTPException(status_code=404, detail="User not found")

--- a/fastapi_app/app/services/file_mapper.py
+++ b/fastapi_app/app/services/file_mapper.py
@@ -272,7 +272,9 @@ class FileToObjectMapper:
     def _get_folder_content(self, path: Path) -> List[str]:
         if not path.is_dir():
             return []
-        return [entry.name for entry in path.iterdir()]
+        # Keep filesystem traversal deterministic so observation ordering does not
+        # change between operating systems/filesystems (stable ingest + tests).
+        return sorted(entry.name for entry in path.iterdir())
 
     def _find_files(self, entries: Iterable[str], suffix: str) -> List[str]:
         suffix_lower = suffix.lower()

--- a/fastapi_app/tests/conftest.py
+++ b/fastapi_app/tests/conftest.py
@@ -19,6 +19,9 @@ if TEST_DB_PATH.exists():
 os.environ.setdefault("DATABASE_URL", f"sqlite:///{TEST_DB_PATH}")
 os.environ.setdefault("JWT_SECRET_KEY", "test-secret")
 os.environ.setdefault("ACCESS_TOKEN_EXPIRE_MINUTES", "60")
+os.environ.setdefault("SMTP_SENDER", "noreply@example.com")
+os.environ.setdefault("CONTACT_RECIPIENT", "contact-test@example.com")
+os.environ.setdefault("METEOR_REPORT_RECIPIENT", "meteor-test@example.com")
 
 from fastapi_app.app.config import get_settings
 from fastapi_app.app.db import Base, SessionLocal, engine, get_session

--- a/fastapi_app/tests/test_api_compat.py
+++ b/fastapi_app/tests/test_api_compat.py
@@ -357,6 +357,7 @@ def test_forms_recaptcha_failure_has_legacy_message_shape(client, monkeypatch):
     assert report.status_code == 401
     assert "message" in report.json()
     assert "error" in report.json()
+    assert "Observasjon mottatt" in report.json()["message"]
 
 
 def test_reportmeteor_accepts_multipart_attachments(client, monkeypatch):

--- a/fastapi_app/tests/test_auth_users_logs_edges.py
+++ b/fastapi_app/tests/test_auth_users_logs_edges.py
@@ -60,6 +60,29 @@ def test_login_rejects_wrong_password(client, db_session, monkeypatch):
     assert response.json()["detail"] == "Feil brukernavn eller passord"
 
 
+def test_login_rejects_unconfirmed_account(client, db_session, monkeypatch):
+    monkeypatch.setattr(
+        user_service_module, "verify_password", lambda plain, stored: plain == stored
+    )
+    user = User(
+        username="unconfirmed@example.com",
+        password="correct-password",
+        role="ROLE_USER",
+        user_level="1",
+        confirmed=False,
+    )
+    db_session.add(user)
+    db_session.commit()
+
+    response = client.post(
+        "/api/auth/login",
+        json={"identifier": "unconfirmed@example.com", "password": "correct-password"},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Feil brukernavn eller passord"
+
+
 def test_password_reset_confirm_rejects_unknown_token(client, db_session):
     user = User(
         username="reset-confirm@example.com",
@@ -239,6 +262,71 @@ def test_user_route_requires_auth_and_rejects_invalid_or_stale_token(client):
     stale = client.get("/api/users/1", headers={"Authorization": f"Bearer {stale_token}"})
     assert stale.status_code == 401
     assert stale.json()["detail"] == "User no longer exists"
+
+
+def test_user_route_forbids_regular_user_from_reading_other_user(client, db_session):
+    own_user = User(
+        username="own-user@example.com",
+        password="pw",
+        role="ROLE_USER",
+        user_level="1",
+        confirmed=True,
+    )
+    other_user = User(
+        username="other-user@example.com",
+        password="pw",
+        role="ROLE_USER",
+        user_level="1",
+        confirmed=True,
+    )
+    db_session.add_all([own_user, other_user])
+    db_session.commit()
+
+    response = client.get(f"/api/users/{other_user.id}", headers=_auth_header(own_user))
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Not authorized"
+
+
+def test_user_route_allows_admin_to_read_other_user(client, db_session):
+    admin_user = User(
+        username="admin-user@example.com",
+        password="pw",
+        role="ROLE_ADMIN",
+        user_level="1",
+        confirmed=True,
+    )
+    other_user = User(
+        username="other-user-2@example.com",
+        password="pw",
+        role="ROLE_USER",
+        user_level="1",
+        confirmed=True,
+    )
+    db_session.add_all([admin_user, other_user])
+    db_session.commit()
+
+    response = client.get(f"/api/users/{other_user.id}", headers=_auth_header(admin_user))
+
+    assert response.status_code == 200
+    assert response.json()["id"] == other_user.id
+
+
+def test_user_route_allows_regular_user_to_read_own_user(client, db_session):
+    own_user = User(
+        username="own-user-2@example.com",
+        password="pw",
+        role="ROLE_USER",
+        user_level="1",
+        confirmed=True,
+    )
+    db_session.add(own_user)
+    db_session.commit()
+
+    response = client.get(f"/api/users/{own_user.id}", headers=_auth_header(own_user))
+
+    assert response.status_code == 200
+    assert response.json()["id"] == own_user.id
 
 
 def test_admin_eventboard_rejects_non_admin_user(client, db_session):

--- a/fastapi_app/tests/test_openapi_contract.py
+++ b/fastapi_app/tests/test_openapi_contract.py
@@ -266,6 +266,12 @@ def test_openapi_exposes_filters_station_logs_and_path_lookup(client):
         payload,
         _response_schema(payload, "/api/users/{user_id}"),
     )
+    user_path_get = paths["/api/users/{user_id}"]["get"]
+    assert (
+        user_path_get["description"]
+        == "Returns account fields for one authenticated user. This is not a public profile endpoint."
+    )
+    assert user_path_get["security"] == [{"HTTPBearer": []}]
     assert "properties" in user_response
     assert {
         "id",

--- a/fastapi_app/tests/test_router_branch_coverage.py
+++ b/fastapi_app/tests/test_router_branch_coverage.py
@@ -165,8 +165,8 @@ def test_users_create_and_self_service_edges(client, db_session, monkeypatch):
     db_session.commit()
 
     missing = client.get("/api/users/9999", headers=_auth_header(owner))
-    assert missing.status_code == 404
-    assert missing.json()["detail"] == "User not found"
+    assert missing.status_code == 403
+    assert missing.json()["detail"] == "Not authorized"
 
     denied_tutorial = client.put(
         f"/api/users/{other.id}/tutorial-completion",


### PR DESCRIPTION
### Motivation

- Consolidate multiple open PR branches targeting `feature/fastapi-port` to bring together bug fixes, test stabilizations and small API behavior changes into a single branch for integration.
- Resolve merge conflicts that arose from overlapping changes to file-system ordering and test environment defaults to ensure deterministic ingest behavior and reliable test runs.

### Description

- Merged the head branches for the open PRs targeting `feature/fastapi-port` (heads: `codex/update-get_user-function-in-users.py`, `codex/find-and-fix-important-bug`, `codex/find-bug-and-suggest-change`, `codex/find-bug-and-suggest-change-8w0hkj`, `codex/investigate-inconsistencies-and-propose-changes`, `codex/investigate-inconsistencies-and-propose-changes-iuulp5`) into the local `feature/fastapi-port` branch.
- Resolved a conflict in `fastapi_app/app/services/file_mapper.py` by enforcing deterministic folder traversal and returning `sorted(entry.name for entry in path.iterdir())` in `FileToObjectMapper._get_folder_content` to stabilize ingest ordering across platforms.
- Resolved a conflict in `fastapi_app/tests/conftest.py` and added test environment defaults `SMTP_SENDER`, `CONTACT_RECIPIENT`, and `METEOR_REPORT_RECIPIENT` so mail-related form tests have recipients configured in the test environment.
- Applied behavior and test updates: block login for unconfirmed accounts in `fastapi_app/app/routers/auth.py` (`login` now rejects when `user.confirmed` is false), restrict `GET /api/users/{user_id}` to account owner or admin in `fastapi_app/app/routers/users.py`, change the recaptcha-failure message in `fastapi_app/app/routers/forms.py`, and included corresponding test additions/adjustments under `fastapi_app/tests/` including OpenAPI contract assertions and user-auth tests.
- Created a local merge commit series and prepared a PR body summarizing the merges; push to `origin/feature/fastapi-port` was attempted but could not complete due to missing GitHub HTTPS credentials in this environment.

### Testing

- No full CI or `pytest` run was performed by the merge script in this environment; all merge commits were created and committed locally and the branch is `ahead` of `origin/feature/fastapi-port` by the merged commits.
- Individual PRs contained successful local test runs: the change that added mail-recipient defaults reported `pytest -q fastapi_app/tests` passing (`94 passed, 1 warning`) and the `get_user` authorization changes reported targeted `pytest` runs passing (`5 passed`) as described in their PR descriptions.
- All `git merge` operations for the listed heads completed successfully after resolving the two content conflicts, as recorded in the local commit history.
- `git push origin feature/fastapi-port` failed in this environment due to missing GitHub credentials and thus remote update was not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c786838834832aa8f3fc6cecb34f21)