### PR TITLE
Fix missing PlainTextResponse import in events router

### DIFF
--- a/fastapi_app/app/routers/events.py
+++ b/fastapi_app/app/routers/events.py
@@ -1,6 +1,7 @@
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query
+from fastapi.responses import PlainTextResponse
 from sqlalchemy.orm import Session
 
 from ..db import get_session


### PR DESCRIPTION
### Motivation
- Prevent a startup `NameError` when importing the events router caused by the `/insights/coordinates/export` route referencing `PlainTextResponse` without importing it.

### Description
- Added `from fastapi.responses import PlainTextResponse` to `fastapi_app/app/routers/events.py` so the `response_class=PlainTextResponse` usage is defined and the router can be imported.

### Testing
- Ran `pytest -q fastapi_app/tests/test_runtime_guards.py`, which passed (`3 passed`).
- Ran `pytest -q fastapi_app/tests/test_openapi_contract.py`, which passed (`6 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7971eaa00832a9f7c058ee164c784)