### PR TITLE
Fix coordinate CSV export NameError

### DIFF
--- a/fastapi_app/app/services/event_service.py
+++ b/fastapi_app/app/services/event_service.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import csv
+import io
 from datetime import datetime
 from math import isfinite
 from math import ceil


### PR DESCRIPTION
### Motivation
- The `/api/insights/coordinates/export` path called `io.StringIO()` and `csv.DictWriter` inside `EventService.export_coordinate_insight_csv` but the module lacked the corresponding imports, causing a runtime `NameError` and a failing test.

### Description
- Add `import csv` and `import io` to `fastapi_app/app/services/event_service.py` so the CSV export can create an in-memory buffer and write rows with `csv.DictWriter` as intended.

### Testing
- Ran the targeted test `cd fastapi_app && pytest -q tests/test_thunder_ported_core.py::test_event_filters_and_coordinate_insights` which passed; then ran the full test suite `cd fastapi_app && pytest -q` which completed with all tests passing (98 passed, 1 warning).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c797f622a4832aafbd2d5e8c328d36)